### PR TITLE
Fixed "Split Defender"

### DIFF
--- a/script/c511001238.lua
+++ b/script/c511001238.lua
@@ -1,0 +1,33 @@
+--Split Defender
+local s,id=GetID()
+function s.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_CONTROL)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(s.condition)
+	e1:SetTarget(s.ctltg)
+	e1:SetOperation(s.ctlop)
+	c:RegisterEffect(e1)
+end
+function s.condition(e,tp,eg,ep,ev,re,r,rp,chk)
+	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>=2
+end
+function s.filter(c)
+	return c:IsControlerCanBeChanged() and c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
+function s.ctltg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_CONTROL,nil,1,1-tp,LOCATION_MZONE)
+end
+function s.ctlop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(s.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()==0 then return end
+	local sg=g:GetMaxGroup(Card.GetDefense)
+	if sg:GetCount()>1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
+		sg=sg:Select(1-tp,1,1,nil)
+	end
+	Duel.GetControl(sg:GetFirst(),tp)
+end


### PR DESCRIPTION
Fixed a bug where it would be possible to activate the card even if the only monsters the opponent controlled were Link monsters