### PR TITLE
Apple of Enlightenment fix

### DIFF
--- a/script/c100000545.lua
+++ b/script/c100000545.lua
@@ -1,0 +1,35 @@
+--フライアのリンゴ
+function c100000545.initial_effect(c)
+	--draw
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(100000545,0))
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetCondition(c100000545.drcon)
+	e1:SetTarget(c100000545.drtg)
+	e1:SetOperation(c100000545.drop)
+	c:RegisterEffect(e1)
+	local e3=e1:Clone()
+	e3:SetCode(EVENT_REMOVE)
+	c:RegisterEffect(e3)
+	local e4=e1:Clone()
+	e4:SetCode(EVENT_TO_DECK)
+	c:RegisterEffect(e4)
+	local e5=e1:Clone()
+	e5:SetCode(EVENT_TO_HAND)
+	c:RegisterEffect(e5)
+end
+function c100000545.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+end
+function c100000545.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c100000545.drop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.Draw(tp,1,REASON_EFFECT)
+	end
+end


### PR DESCRIPTION
Added the condition to trigger when it returns to the hand (tested while face-down with hey, trunade).

Effect of the card: 
```
If this card leaves the field: Draw 1 card.
```

What I added:
```lua
        local e5=e1:Clone()
        e5:SetCode(EVENT_TO_HAND)
        c:RegisterEffect(e5)
```

Reported on Discord by `666#7686` (Discord ID: `325807436269223936`)