### PR TITLE
Various Fixes and Updates

### DIFF
--- a/script/c511000995.lua
+++ b/script/c511000995.lua
@@ -1,32 +1,34 @@
 --時読みの魔術師
-function c511000995.initial_effect(c)
+--Timegazer Magician
+local s,id=GetID()
+function s.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
 	--negate and set
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(511000995,0))
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_NEGATE)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetRange(LOCATION_PZONE)
 	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
 	e2:SetCode(EVENT_CHAINING)
 	e2:SetCountLimit(1)
-	e2:SetCondition(c511000995.discon)
-	e2:SetTarget(c511000995.distg)
-	e2:SetOperation(c511000995.disop)
+	e2:SetCondition(s.discon)
+	e2:SetTarget(s.distg)
+	e2:SetOperation(s.disop)
 	c:RegisterEffect(e2)
 	--negate
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(511000995,1))
+	e3:SetDescription(aux.Stringid(id,1))
 	e3:SetCategory(CATEGORY_DISABLE)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_QUICK_O)
 	e3:SetCode(EVENT_CHAINING)
 	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCountLimit(1)
-	e3:SetCondition(c511000995.negcon)
-	e3:SetTarget(c511000995.negtg)
-	e3:SetOperation(c511000995.negop)
+	e3:SetCondition(s.negcon)
+	e3:SetTarget(s.negtg)
+	e3:SetOperation(s.negop)
 	c:RegisterEffect(e3)
 	--Double Snare
 	local e4=Effect.CreateEffect(c)
@@ -36,18 +38,18 @@ function c511000995.initial_effect(c)
 	e4:SetCode(3682106)
 	c:RegisterEffect(e4)
 end
-function c511000995.discon(e,tp,eg,ep,ev,re,r,rp)
+function s.discon(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
 	if not tg or tg:GetCount()~=1 or not tg:GetFirst():IsType(TYPE_PENDULUM) or not tg:GetFirst():IsLocation(LOCATION_MZONE) then return false end
 	return re:IsActiveType(TYPE_TRAP) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
-function c511000995.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
-function c511000995.disop(e,tp,eg,ep,ev,re,r,rp)
+function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsFaceup() or not c:IsRelateToEffect(e) then return end
 	Duel.NegateActivation(ev)
@@ -59,19 +61,19 @@ function c511000995.disop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.RaiseEvent(g,EVENT_SSET,e,REASON_EFFECT,1-tp,1-tp,0)
 	end
 end
-function c511000995.negfilter(c)
-	return c:IsOnField() and (c:GetSequence()==6 or c:GetSequence()==7)
+function s.negfilter(c)
+	return c:IsOnField() and c:IsLocation(LOCATION_PZONE)
 end
-function c511000995.negcon(e,tp,eg,ep,ev,re,r,rp)
+function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	return tg and tg:IsExists(c511000995.negfilter,1,nil) and Duel.IsChainDisablable(ev)
+	return tg and tg:IsExists(s.negfilter,1,nil) and Duel.IsChainDisablable(ev)
 end
-function c511000995.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
-function c511000995.negop(e,tp,eg,ep,ev,re,r,rp)
+function s.negop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateEffect(ev)
 end

--- a/script/c511002003.lua
+++ b/script/c511002003.lua
@@ -1,0 +1,79 @@
+--Performapal Extra Shooter
+local s,id=GetID()
+function s.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--damage
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(95100065,0))
+	e2:SetCategory(CATEGORY_DAMAGE)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetRange(LOCATION_PZONE)
+	e2:SetCountLimit(1)
+	e2:SetCost(s.damcost)
+	e2:SetTarget(s.damtg)
+	e2:SetOperation(s.damop)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(95100065,1))
+	e3:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetCountLimit(1)
+	e3:SetTarget(s.destg)
+	e3:SetOperation(s.desop)
+	c:RegisterEffect(e3)
+	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
+end
+function s.counterfilter(c)
+	return c:GetSummonType()~=SUMMON_TYPE_PENDULUM
+end
+function s.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0 end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(s.splimit)
+	Duel.RegisterEffect(e1,tp)
+end
+function s.splimit(e,c,sump,sumtype,sumpos,targetp,se)
+	return sumtype==SUMMON_TYPE_PENDULUM
+end
+function s.damfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_PENDULUM)
+end
+function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ct=Duel.GetMatchingGroupCount(s.damfilter,tp,LOCATION_EXTRA,0,nil)
+	if chk==0 then return ct>0 end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,ct*300)
+end
+function s.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local ct=Duel.GetMatchingGroupCount(s.damfilter,tp,LOCATION_EXTRA,0,nil)
+	Duel.Damage(p,ct*300,REASON_EFFECT)
+end
+function s.filter(c)
+	return c:IsDestructable()
+end
+function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_PZONE) and chkc:IsControler(tp) and s.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.filter,tp,LOCATION_PZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_PZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,300)
+end
+function s.desop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		Duel.Damage(1-tp,300,REASON_EFFECT)
+	end
+end

--- a/script/c511002005.lua
+++ b/script/c511002005.lua
@@ -1,15 +1,16 @@
---Performapal Extra Shooter
-function c511002005.initial_effect(c)
+--Performapal Sandwich Wingman
+local s,id=GetID()
+function s.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(95100067,0))
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
-	e1:SetCode(511002005)
+	e1:SetCode(EVENT_CUSTOM+id)
 	e1:SetRange(LOCATION_PZONE)
-	e1:SetTarget(c511002005.sctg)
-	e1:SetOperation(c511002005.scop)
+	e1:SetTarget(s.sctg)
+	e1:SetOperation(s.scop)
 	c:RegisterEffect(e1)
 	--lvup
 	local e2=Effect.CreateEffect(c)
@@ -17,7 +18,7 @@ function c511002005.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1)
-	e2:SetOperation(c511002005.lvop)
+	e2:SetOperation(s.lvop)
 	c:RegisterEffect(e2)
 	--lv change
 	local e3=Effect.CreateEffect(c)
@@ -26,43 +27,43 @@ function c511002005.initial_effect(c)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCountLimit(1)
 	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e3:SetTarget(c511002005.lvtg2)
-	e3:SetOperation(c511002005.lvop2)
+	e3:SetTarget(s.lvtg2)
+	e3:SetOperation(s.lvop2)
 	c:RegisterEffect(e3)
-	if not c511002005.global_check then
-		c511002005.global_check=true
-		local ge2=Effect.CreateEffect(c)
-		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge2:SetCode(EVENT_ADJUST)
-		ge2:SetOperation(c511002005.checkop)
-		Duel.RegisterEffect(ge2,0)
+	if not s.global_check then
+		s.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_ADJUST)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
 	end
 end
-function c511002005.cfilter(c)
+function s.cfilter(c)
 	local seq=c:GetSequence()
-	return c:GetFlagEffect(511002005+seq)==0 and (not c:IsPreviousLocation(LOCATION_PZONE) or c:GetPreviousSequence()~=seq)
+	return c:GetFlagEffect(id+seq)==0 and (not c:IsPreviousLocation(LOCATION_PZONE) or c:GetPreviousSequence()~=seq)
 end
-function c511002005.checkop(e,tp,eg,ep,ev,re,r,rp)
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tot=Duel.GetMasterRule()>=4 and 4 or 13
-	local g=Duel.GetMatchingGroup(c511002005.cfilter,tp,LOCATION_PZONE,LOCATION_PZONE,nil)
+	local g=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_PZONE,LOCATION_PZONE,nil)
 	local tc=g:GetFirst()
 	while tc do
-		tc:ResetFlagEffect(511002005+tot-tc:GetSequence())
-		Duel.RaiseSingleEvent(tc,511002005,e,0,tp,tp,0)
-		tc:RegisterFlagEffect(511002005+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
+		tc:ResetFlagEffect(id+tot-tc:GetSequence())
+		Duel.RaiseSingleEvent(tc,EVENT_CUSTOM+id,e,0,tp,tp,0)
+		tc:RegisterFlagEffect(id+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
 		tc=g:GetNext()
 	end
 end
-function c511002005.filter(c)
+function s.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_PENDULUM)
 end
-function c511002005.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_SZONE) and c511002005.filter(chkc) end
-	if chk==0 then return Duel.IsExistingMatchingCard(c511002005.filter,tp,LOCATION_MZONE,0,1,nil) end
+function s.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_Mge1ZONE) and s.filter(chkc) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c511002005.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,s.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
-function c511002005.scop(e,tp,eg,ep,ev,re,r,rp)
+function s.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
@@ -80,7 +81,7 @@ function c511002005.scop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e2)
 	end
 end
-function c511002005.lvop(e,tp,eg,ep,ev,re,r,rp)
+function s.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFaceup() and c:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
@@ -92,33 +93,33 @@ function c511002005.lvop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 	end
 end
-function c511002005.seqfilter(c,e,tp,seq1,lv,e2)
+function s.seqfilter(c,e,tp,seq1,lv,e2)
 	local lvtg=c:GetLevel()
 	local seq=c:GetSequence()
 	return (seq==1 or seq==2 or seq==3) and lvtg~=lv and (not e or c:IsRelateToEffect(e)) 
 		and (not e2 or c:IsCanBeEffectTarget(e2))
-		and Duel.IsExistingMatchingCard(c511002005.seqfilter2,tp,LOCATION_MZONE,0,1,nil,seq1,lv,seq)
+		and Duel.IsExistingMatchingCard(s.seqfilter2,tp,LOCATION_MZONE,0,1,nil,seq1,lv,seq)
 end
-function c511002005.seqfilter2(c,seq1,lv1,seq)
+function s.seqfilter2(c,seq1,lv1,seq)
 	local seq2=c:GetSequence()
 	return c:IsFaceup() and c:GetLevel()==lv1 and ((seq1>seq and seq>seq2) or (seq2>seq and seq>seq1))
 end
-function c511002005.lvtg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+function s.lvtg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local seq=e:GetHandler():GetSequence()
 	local lv=e:GetHandler():GetLevel()
-	local ct1=Duel.GetMatchingGroupCount(c511002005.seqfilter,tp,LOCATION_MZONE,0,nil,nil,tp,seq,lv,nil)
-	local ct2=Duel.GetMatchingGroupCount(c511002005.seqfilter,tp,LOCATION_MZONE,0,nil,nil,tp,seq,lv,e)
+	local ct1=Duel.GetMatchingGroupCount(s.seqfilter,tp,LOCATION_MZONE,0,nil,nil,tp,seq,lv,nil)
+	local ct2=Duel.GetMatchingGroupCount(s.seqfilter,tp,LOCATION_MZONE,0,nil,nil,tp,seq,lv,e)
 	if chkc then return false end
 	if chk==0 then return ct1>0 and ct2>0 and ct1==ct2 end
-	local g=Duel.GetMatchingGroup(c511002005.seqfilter,tp,LOCATION_MZONE,0,nil,nil,tp,seq,lv,e)
+	local g=Duel.GetMatchingGroup(s.seqfilter,tp,LOCATION_MZONE,0,nil,nil,tp,seq,lv,e)
 	Duel.SetTargetCard(g)
 end
-function c511002005.lvop2(e,tp,eg,ep,ev,re,r,rp)
+function s.lvop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	local seq=c:GetSequence()
 	local lv=c:GetLevel()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c511002005.seqfilter,nil,e,tp,seq,lv,nil)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(s.seqfilter,nil,e,tp,seq,lv,nil)
 	local tc=g:GetFirst()
 	while tc do
 		local e1=Effect.CreateEffect(c)

--- a/script/c511009363.lua
+++ b/script/c511009363.lua
@@ -1,6 +1,7 @@
 --Spirit Reactor
 --fixed by MLD
-function c511009363.initial_effect(c)
+local s,id=GetID()
+function s.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
 	--atk
@@ -9,7 +10,7 @@ function c511009363.initial_effect(c)
 	e1:SetCode(EFFECT_UPDATE_ATTACK)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetValue(c511009363.val)
+	e1:SetValue(s.val)
 	c:RegisterEffect(e1)
 	--indes
 	local e2=Effect.CreateEffect(c)
@@ -17,68 +18,68 @@ function c511009363.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
 	e2:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
 	e2:SetRange(LOCATION_PZONE)
-	e2:SetCondition(c511009363.indcon)
+	e2:SetCondition(s.indcon)
 	e2:SetTargetRange(LOCATION_MZONE,0)
-	e2:SetValue(c511009363.indct)
+	e2:SetValue(s.indct)
 	c:RegisterEffect(e2)
 	-- copy scale
-	local e8=Effect.CreateEffect(c)
-	e8:SetDescription(aux.Stringid(94585852,0))
-	e8:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e8:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
-	e8:SetCode(511002005)
-	e8:SetRange(LOCATION_PZONE)
-	e8:SetTarget(c511009363.sctg)
-	e8:SetOperation(c511009363.scop)
-	c:RegisterEffect(e8)
-	if not c511009363.global_check then
-		c511009363.global_check=true
-		local ge2=Effect.CreateEffect(c)
-		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge2:SetCode(EVENT_ADJUST)
-		ge2:SetOperation(c511009363.checkop)
-		Duel.RegisterEffect(ge2,0)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(94585852,0))
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_CUSTOM+id)
+	e3:SetRange(LOCATION_PZONE)
+	e3:SetTarget(s.sctg)
+	e3:SetOperation(s.scop)
+	c:RegisterEffect(e3)
+	if not s.global_check then
+		s.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_ADJUST)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
 	end
 end
-function c511009363.val(e,c)
-	return Duel.GetMatchingGroupCount(c511009363.filter,c:GetControler(),LOCATION_MZONE,LOCATION_MZONE,nil)*500
+function s.val(e,c)
+	return Duel.GetMatchingGroupCount(s.filter,c:GetControler(),LOCATION_MZONE,LOCATION_MZONE,nil)*500
 end
-function c511009363.filter(c)
+function s.filter(c)
 	return c:IsAttribute(ATTRIBUTE_EARTH+ATTRIBUTE_WATER+ATTRIBUTE_FIRE+ATTRIBUTE_WIND) and c:IsFaceup()
 end
-function c511009363.indcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c511009363.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
+function s.indcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
 end
-function c511009363.indct(e,re,r,rp)
+function s.indct(e,re,r,rp)
 	if r&REASON_BATTLE+REASON_EFFECT~=0 then
 		return 1
 	else return 0 end
 end
-function c511009363.cfilter(c)
+function s.cfilter(c)
 	local seq=c:GetSequence()
-	return c:GetFlagEffect(511002005+seq)==0 and (not c:IsPreviousLocation(LOCATION_PZONE) or c:GetPreviousSequence()~=seq)
+	return c:GetFlagEffect(id+seq)==0 and (not c:IsPreviousLocation(LOCATION_PZONE) or c:GetPreviousSequence()~=seq)
 end
-function c511009363.checkop(e,tp,eg,ep,ev,re,r,rp)
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tot=Duel.GetMasterRule()>=4 and 4 or 13
-	local g=Duel.GetMatchingGroup(c511009363.cfilter,tp,LOCATION_PZONE,LOCATION_PZONE,nil)
+	local g=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_PZONE,LOCATION_PZONE,nil)
 	local tc=g:GetFirst()
 	while tc do
-		tc:ResetFlagEffect(511002005+tot-tc:GetSequence())
-		Duel.RaiseSingleEvent(tc,511002005,e,0,tp,tp,0)
-		tc:RegisterFlagEffect(511002005+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
+		tc:ResetFlagEffect(id+tot-tc:GetSequence())
+		Duel.RaiseSingleEvent(tc,EVENT_CUSTOM+id,e,0,tp,tp,0)
+		tc:RegisterFlagEffect(id+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
 		tc=g:GetNext()
 	end
 end
-function c511009363.scfilter(c)
+function s.scfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_PENDULUM)
 end
-function c511009363.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc~=e:GetHandler() and chkc:IsOnField() and c511009363.scfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c511009363.scfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
+function s.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc~=e:GetHandler() and chkc:IsOnField() and s.scfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.scfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c511009363.scfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
+	Duel.SelectTarget(tp,s.scfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
 end
-function c511009363.scop(e,tp,eg,ep,ev,re,r,rp)
+function s.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsFaceup() and c:IsRelateToEffect(e) and tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then

--- a/script/c511009369.lua
+++ b/script/c511009369.lua
@@ -1,47 +1,48 @@
 --Timebreaker Magician (Anime)
 --fixed by MLD
-function c511009369.initial_effect(c)
+local s,id=GetID()
+function s.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
 	--double
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(s.atkcon)
+	e1:SetOperation(s.atkop)
+	c:RegisterEffect(e1)
+	--Cannot Attack Directly
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+	c:RegisterEffect(e2)
+	--Double Scale
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e3:SetCondition(c511009369.atkcon)
-	e3:SetOperation(c511009369.atkop)
+	e3:SetDescription(aux.Stringid(94585852,0))
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_CUSTOM+id)
+	e3:SetRange(LOCATION_PZONE)
+	e3:SetTarget(s.sctg)
+	e3:SetOperation(s.scop)
 	c:RegisterEffect(e3)
-	--
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE)
-	e4:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
-	c:RegisterEffect(e4)
-	-- copy scale
-	local e8=Effect.CreateEffect(c)
-	e8:SetDescription(aux.Stringid(94585852,0))
-	e8:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e8:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
-	e8:SetCode(511002005)
-	e8:SetRange(LOCATION_PZONE)
-	e8:SetTarget(c511009369.sctg)
-	e8:SetOperation(c511009369.scop)
-	c:RegisterEffect(e8)
-	if not c511009369.global_check then
-		c511009369.global_check=true
-		local ge2=Effect.CreateEffect(c)
-		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge2:SetCode(EVENT_ADJUST)
-		ge2:SetOperation(c511009369.checkop)
-		Duel.RegisterEffect(ge2,0)
+	if not s.global_check then
+		s.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_ADJUST)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
 	end
 end
-function c511009369.atkcon(e,tp,eg,ep,ev,re,r,rp)
+function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return eg:GetCount()==1 and eg:GetFirst()==c
 		and c:GetSummonType()==SUMMON_TYPE_PENDULUM and c:IsPreviousLocation(LOCATION_HAND)
 end
-function c511009369.atkop(e,tp,eg,ep,ev,re,r,rp)
+function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFaceup() and c:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
@@ -52,28 +53,28 @@ function c511009369.atkop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 	end
 end
-function c511009369.cfilter(c)
+function s.cfilter(c)
 	local seq=c:GetSequence()
-	return c:GetFlagEffect(511002005+seq)==0 and (not c:IsPreviousLocation(LOCATION_PZONE) or c:GetPreviousSequence()~=seq)
+	return c:GetFlagEffect(id+seq)==0 and (not c:IsPreviousLocation(LOCATION_PZONE) or c:GetPreviousSequence()~=seq)
 end
-function c511009369.checkop(e,tp,eg,ep,ev,re,r,rp)
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tot=Duel.GetMasterRule()>=4 and 4 or 13
-	local g=Duel.GetMatchingGroup(c511009369.cfilter,tp,LOCATION_PZONE,LOCATION_PZONE,nil)
+	local g=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_PZONE,LOCATION_PZONE,nil,e)
 	local tc=g:GetFirst()
 	while tc do
-		tc:ResetFlagEffect(511002005+tot-tc:GetSequence())
-		Duel.RaiseSingleEvent(tc,511002005,e,0,tp,tp,0)
-		tc:RegisterFlagEffect(511002005+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
+		tc:ResetFlagEffect(id+tot-tc:GetSequence())
+		Duel.RaiseSingleEvent(tc,EVENT_CUSTOM+id,e,0,tp,tp,0)
+		tc:RegisterFlagEffect(id+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
 		tc=g:GetNext()
 	end
 end
-function c511009369.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+function s.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_PZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
 	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_PZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_PZONE,0,1,1,nil)
 end
-function c511009369.scop(e,tp,eg,ep,ev,re,r,rp)
+function s.scop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())

--- a/script/c700000009.lua
+++ b/script/c700000009.lua
@@ -1,6 +1,5 @@
 --Scripted by Eerie Code
 --Performapal Odd-Eyes Light Phoenix
---Needs a fix for strings
 local s,id=GetID()
 function s.initial_effect(c)
 	--pendulum summon

--- a/script/c700000009.lua
+++ b/script/c700000009.lua
@@ -1,0 +1,58 @@
+--Scripted by Eerie Code
+--Performapal Odd-Eyes Light Phoenix
+--Needs a fix for strings
+local s,id=GetID()
+function s.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--Special Summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_PZONE)
+	e2:SetCondition(s.spcon)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--destroy replace
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,1))
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetCode(EFFECT_DESTROY_REPLACE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTarget(s.reptg)
+	c:RegisterEffect(e3)
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local at=Duel.GetAttacker()
+	return at:IsControler(1-tp) and Duel.GetAttackTarget()==nil
+end
+
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstMatchingCard(nil,tp,LOCATION_PZONE,0,c)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.Destroy(tc,REASON_EFFECT)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+end
+function s.repfil(c)
+	return c:IsDestructable()
+end
+function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReason(REASON_BATTLE) and Duel.IsExistingMatchingCard(s.repfil,tp,LOCATION_PZONE,0,1,nil) end
+	if Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
+		local g=Duel.SelectMatchingCard(tp,s.repfil,tp,LOCATION_PZONE,0,1,1,nil)
+		Duel.Destroy(g,REASON_EFFECT+REASON_REPLACE)
+		return true
+	else return false end
+end

--- a/script/c700000015.lua
+++ b/script/c700000015.lua
@@ -1,0 +1,47 @@
+--Scripted by Eerie Code
+--Abyss Actor - Extra
+local s,id=GetID()
+function s.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--Special Summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_PZONE)
+	e2:SetCondition(s.spcon)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--Set in P.Zone
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTarget(s.pztg)
+	e3:SetOperation(s.pzop)	
+	c:RegisterEffect(e3)
+end
+
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0 and e:GetHandler():GetFlagEffect(id)==0
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function s.pztg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_PZONE,0)<2 end
+end
+function s.pzop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+		c:RegisterFlagEffect(id,RESET_EVENT+0xfc0000+RESET_PHASE+PHASE_END,0,1)
+	end
+end


### PR DESCRIPTION
Fixed "If this card is placed in the Pendulum Zone:" clauses for: (Were missing EVENT_CUSTOM+id in the Raise)
-Timebreaker Magician
-Performage Wing Sandwichman
-Spirit Reactor
Fixed old c:GetSequence used in:
-Timegazer Magician
-Performapal Extra Slinger
-Performapal Odd-Eyes Light Phoenix
-Abyss Actor - Extras