### PR TITLE
"Armatos Gloria" fix

### DIFF
--- a/script/c511030009.lua
+++ b/script/c511030009.lua
@@ -11,7 +11,7 @@ function s.initial_effect(c)
 	--indestructible
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_INDESTRUCTABLE)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
 	e2:SetValue(s.indval)


### PR DESCRIPTION
The "cannot be destroyed" effect had the wrong code, which made it check for battle destruction as well, in which case it returned an error because there was no effect causing the destruction.