### PR TITLE
Fix to "Cubed Hydradrive Lord"

### DIFF
--- a/script/c511106013.lua
+++ b/script/c511106013.lua
@@ -5,7 +5,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--link summon
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkSetCard,0x577),3,3,s.spcheck)
+	aux.AddLinkProcedure(c,s.matfilter,3,3,s.spcheck)
 	--attribute
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
@@ -43,6 +43,9 @@ function s.initial_effect(c)
 	e4:SetTarget(s.drtg)
 	e4:SetOperation(s.drop)
 	c:RegisterEffect(e4)
+end
+function s.matfilter(c,scard,sumtype,tp)
+	return c:IsType(TYPE_LINK,scard,sumtype,tp) and c:IsLinkSetCard(0x577,scard,sumtype,tp)
 end
 function s.spcheck(g,lc,tp)
 	return g:CheckSameProperty(Card.GetAttribute,lc,SUMMON_TYPE_LINK,tp)


### PR DESCRIPTION
Previously it would be possible to use a non-Link Hydradrive as material for its summon