### PR TITLE
Fix for "Perfectron Hydradrive Dragon"

### DIFF
--- a/script/c511027001.lua
+++ b/script/c511027001.lua
@@ -45,7 +45,7 @@ function s.initial_effect(c)
 	--destroy and deal damage
 	local e5=Effect.CreateEffect(c)
 	e5:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
-	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e5:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e5:SetCode(EVENT_BATTLED)
 	e5:SetRange(LOCATION_MZONE)


### PR DESCRIPTION
Was activating its effect when any you control monster battled.