### PR TITLE
Fix Centaur Mina (+need change in the cdb)

### DIFF
--- a/script/c500000143.lua
+++ b/script/c500000143.lua
@@ -1,0 +1,52 @@
+--ケンタウルミナ
+local s,id=GetID()
+function s.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,true,true,500000141,500000142)
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetCondition(s.discon)
+	e1:SetTarget(s.distg)
+	e1:SetOperation(s.disop)
+	c:RegisterEffect(e1)
+end
+function s.discon(e,tp,eg,ep,ev,re,r,rp)
+	return re:IsActiveType(TYPE_TRAP) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
+		and rp~=tp and tp==Duel.GetTurnPlayer()
+end
+function s.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if not re:GetHandler():IsStatus(STATUS_ACT_FROM_HAND) then
+			return re:GetHandler():IsCanTurnSet()
+		else return true end
+	end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsRelateToEffect(re) and re:GetHandler():IsStatus(STATUS_ACT_FROM_HAND) then
+		Duel.SetOperationInfo(0,CATEGORY_TOHAND,eg,1,0,0)
+	end
+end
+function s.disop(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	if Duel.NegateActivation(ev) and rc:IsRelateToEffect(re) then
+		if rc:IsStatus(STATUS_ACT_FROM_HAND) then
+			rc:CancelToGrave()
+			Duel.SendtoHand(rc,nil,REASON_EFFECT)
+		else
+			if rc:IsCanTurnSet() then
+				rc:CancelToGrave()
+				Duel.ChangePosition(rc,POS_FACEDOWN)
+				rc:SetStatus(STATUS_ACTIVATE_DISABLED,false)
+				rc:SetStatus(STATUS_SET_TURN,false)
+				Duel.RaiseEvent(rc,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
+			end
+		end
+	end
+end

--- a/script/c500000143.lua
+++ b/script/c500000143.lua
@@ -1,4 +1,5 @@
 --ケンタウルミナ
+--Centaur Mina
 local s,id=GetID()
 function s.initial_effect(c)
 	--fusion material


### PR DESCRIPTION
According to Yugipedia, there's an error with the effect of Centaur Mina, according to yugipedia, the negated trap card should return to it's original position and not set.

https://yugipedia.com/wiki/Centaur_Mina