### PR TITLE
Fix for "Topologina Honeycomb Beehicle"

### DIFF
--- a/script/c511030052.lua
+++ b/script/c511030052.lua
@@ -33,7 +33,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.filter(c)
-	return c:IsSetCard(0x57b) and c:IsAbleToHand()
+	return c:IsSetCard(0x57b) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end


### PR DESCRIPTION
Should be able to searh "Topologina" monsters only when activated.