### PR TITLE
"Performage Trapeze Witch" fix

### DIFF
--- a/script/c511009105.lua
+++ b/script/c511009105.lua
@@ -1,0 +1,76 @@
+--Performage Trapeze Force Witch
+local s,id=GetID()
+function s.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMixN(c,true,true,aux.FilterBoolFunction(Card.IsFusionSetCard,0xc6),2)
+	--indes
+	local e2=Effect.CreateEffect(c)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetTarget(s.target)
+	e2:SetValue(1)
+	c:RegisterEffect(e2)
+	--cannot be target
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e3:SetValue(aux.tgoval)
+	c:RegisterEffect(e3)
+	--cannot be effect target
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+	e4:SetCondition(s.atcon)
+	e4:SetValue(1)
+	c:RegisterEffect(e4)
+	--atk
+	local e5=Effect.CreateEffect(c)
+	e5:SetCategory(CATEGORY_ATKCHANGE)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e5:SetCode(EVENT_BATTLE_START)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e5:SetCondition(s.atkcon)
+	e5:SetTarget(s.atktg)
+	e5:SetOperation(s.atkop)
+	c:RegisterEffect(e5)
+end
+s.material_setcode=0xc6
+function s.target(e,c)
+	return c:IsSetCard(0xc6)
+end
+function s.atfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xc6)
+end
+function s.atcon(e)
+	return Duel.IsExistingMatchingCard(s.atfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,e:GetHandler())
+end
+function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	local bc=Duel.GetAttackTarget()
+	if not bc then return false end
+	if bc:IsControler(1-tp) then bc=tc end
+	e:SetLabelObject(bc:GetBattleTarget())
+	return bc:IsFaceup() and bc:IsSetCard(0xc6)
+end
+function s.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tc=e:GetLabelObject()
+	if chkc then return chkc==tc end
+	if chk==0 then
+		return tc:IsOnField() and tc:IsFaceup() and tc:IsCanBeEffectTarget(e)
+	end
+	Duel.SetTargetCard(tc)
+end
+function s.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(-600)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/script/c511009105.lua
+++ b/script/c511009105.lua
@@ -1,4 +1,5 @@
---Performage Trapeze Force Witch
+--Ｅｍトラピーズ・フォーズ・ウィッチ
+--Performage Trapeze Witch
 local s,id=GetID()
 function s.initial_effect(c)
 	--fusion material


### PR DESCRIPTION
Updated the condition used for the ATK increase effect to prevent it from being activated when a non-"Performage" monster battles