### PR TITLE
Fixed Fairy Tail field spell cards

### DIFF
--- a/script/c100000330.lua
+++ b/script/c100000330.lua
@@ -1,0 +1,78 @@
+--Ｆａｉｒｙ Ｔａｌｅ序章 旅立ちの暁光
+--Fairy Tale Prologue: Journey's Dawn
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--unnegatable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_PREDRAW)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e3:SetCondition(s.actcond)
+	e3:SetOperation(s.actop)
+	c:RegisterEffect(e3)
+	local e2=e3:Clone()
+	e2:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	c:RegisterEffect(e2)
+	--Halve Damage
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetRange(LOCATION_FZONE)
+	e4:SetCode(EFFECT_CHANGE_DAMAGE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetTargetRange(1,1)
+	e4:SetValue(s.value)
+	c:RegisterEffect(e4)
+	if not s.global_check then
+		s.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
+end
+function s.value(e,re,dam,r,rp,rc)
+	if bit.band(r,REASON_BATTLE)~=0 then
+		return dam/2
+	else
+		return dam
+	end
+end
+function s.actcond(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp and e:GetHandler():GetTurnID()~=Duel.GetTurnCount()
+end
+function s.filter(c,tp)
+	return c:IsCode(100000331) and c:GetActivateEffect():IsActivatable(tp)
+end
+function s.actop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_GRAVE+LOCATION_HAND+LOCATION_DECK,0,1,1,nil,tp):GetFirst()
+	if tc then
+		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+		if fc then
+			Duel.SendtoGrave(fc,REASON_RULE)
+			Duel.BreakEffect()
+		end
+		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+		local te=tc:GetActivateEffect()
+		local tep=tc:GetControler()
+		local cost=te:GetCost()
+		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
+	end
+end

--- a/script/c100000331.lua
+++ b/script/c100000331.lua
@@ -1,0 +1,78 @@
+--Ｆａｉｒｙ Ｔａｌｅ 第二章 暴怒の太陽
+--Fairy Tale Chapter 2: Seething Sun
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--unnegatable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_PREDRAW)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e3:SetCondition(s.accon)
+	e3:SetOperation(s.acop)
+	c:RegisterEffect(e3)
+	local e2=e3:Clone()
+	e2:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	c:RegisterEffect(e2)
+	--damage
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetRange(LOCATION_FZONE)
+	e4:SetCode(EFFECT_CHANGE_DAMAGE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetTargetRange(1,1)
+	e4:SetValue(s.value)
+	c:RegisterEffect(e4)
+	if not s.global_check then
+		s.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
+end
+function s.value(e,re,dam,r,rp,rc)
+	if bit.band(r,REASON_BATTLE)~=0 then
+		return dam*2
+	else
+		return dam
+	end
+end
+function s.accon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp and e:GetHandler():GetTurnID()~=Duel.GetTurnCount()
+end
+function s.filter(c,tp)
+	return c:IsCode(100000332) and c:GetActivateEffect():IsActivatable(tp)
+end
+function s.acop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_GRAVE+LOCATION_HAND+LOCATION_DECK,0,1,1,nil,tp):GetFirst()
+	if tc then
+		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+		if fc then
+			Duel.SendtoGrave(fc,REASON_RULE)
+			Duel.BreakEffect()
+		end
+		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+		local te=tc:GetActivateEffect()
+		local tep=tc:GetControler()
+		local cost=te:GetCost()
+		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
+	end
+end

--- a/script/c100000332.lua
+++ b/script/c100000332.lua
@@ -1,0 +1,89 @@
+--Ｆａｉｒｙ Ｔａｌｅ第三章 黄昏の夕日
+--Fairy Tale Chapter 3: Evening Sun
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_BOTH_SIDE)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--unnegatable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_PREDRAW)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e3:SetCondition(s.accon)
+	e3:SetOperation(s.actop)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e4:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	c:RegisterEffect(e4)
+	if not s.global_check then
+		s.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
+end
+function s.accon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp and e:GetHandler():GetTurnID()~=Duel.GetTurnCount()
+end
+function s.filter(c,tp)
+	return c:IsCode(100000333) and c:GetActivateEffect():IsActivatable(tp)
+end
+function s.actop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_GRAVE+LOCATION_HAND+LOCATION_DECK,0,1,1,nil,tp):GetFirst()
+	if tc then
+		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+		if fc then
+			Duel.SendtoGrave(fc,REASON_RULE)
+			Duel.BreakEffect()
+		end
+		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+		local te=tc:GetActivateEffect()
+		local tep=tc:GetControler()
+		local cost=te:GetCost()
+		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
+	end
+end
+function s.spfilter(c,e,tp)
+	return c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end

--- a/script/c100000333.lua
+++ b/script/c100000333.lua
@@ -1,0 +1,93 @@
+--Ｆａｉｒｙ Ｔａｌｅ最終章 忘却の妖月
+--Fairy Tale Final Chapter: Moon of Oblivion
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_FIELD)
+	e2:SetCode(EVENT_CHANGE_POS)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTarget(s.postg)
+	e2:SetOperation(s.posop)
+	c:RegisterEffect(e2)	
+	--unnegatable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_PREDRAW)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e3:SetCondition(s.actcond)
+	e3:SetOperation(s.actop)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e4:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	c:RegisterEffect(e4)
+	if not s.global_check then
+		s.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(s.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function s.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
+end
+function s.posfilter(c,e)
+	return bit.band(c:GetPreviousPosition(),POS_DEFENSE)~=0 and c:IsPosition(POS_FACEUP_ATTACK) 
+		and (not e or c:IsRelateToEffect(e))
+end
+function s.postg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return eg:IsExists(s.posfilter,1,nil) and rp==tp end
+	Duel.SetTargetCard(eg)
+end
+function s.posop(e,tp,eg,ep,ev,re,r,rp)
+	local g=eg:Filter(s.posfilter,nil,e)
+	local tc=g:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetValue(tc:GetAttack()*2)
+		tc:RegisterEffect(e1)
+		tc=g:GetNext()
+	end
+end
+function s.actcond(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp and e:GetHandler():GetTurnID()~=Duel.GetTurnCount()
+end
+function s.filter(c,tp)
+	return c:IsCode(100000330) and c:GetActivateEffect():IsActivatable(tp)
+end
+function s.actop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_GRAVE+LOCATION_HAND+LOCATION_DECK,0,1,1,nil,tp):GetFirst()
+	if tc then
+		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+		if fc then
+			Duel.SendtoGrave(fc,REASON_RULE)
+			Duel.BreakEffect()
+		end
+		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+		local te=tc:GetActivateEffect()
+		local tep=tc:GetControler()
+		local cost=te:GetCost()
+		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
+	end
+end
+


### PR DESCRIPTION
They were all using a heavily outdated way to activate the new Field Spell, which would make even the opponent's field spell to be sent to the GY.