### PR TITLE
fix Sunseed Shadow

### DIFF
--- a/script/c511027004.lua
+++ b/script/c511027004.lua
@@ -39,7 +39,7 @@ function s.filter1(c,e,tp)
 		and Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetCode())
 end
 function s.filter2(c,e,tp,tc,code)
-	return c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,tc:GetToBeLinkedZone(c,tp,true))
+	return c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp) and tc:GetToBeLinkedZone(c,tp,true)>0
 end
 function s.spextg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and s.filter1(chkc,e,tp) end


### PR DESCRIPTION
Having the `GetToBeLinkedZone` being in the `IsCanBeSpecialSummoned` function made the target function never become true even when the condition on field are fulfilled. Now the card should get the possibility to be activated when the condition are met.